### PR TITLE
refactor: extract update entries method

### DIFF
--- a/lib/data/network.dart
+++ b/lib/data/network.dart
@@ -67,3 +67,11 @@ Future<void> uploadMockData() async {
       firestoreInstance.collection(trainingPlanCollectionName);
   planEntryCollection.document(documentReference).update(mockupData);
 }
+
+/// Updates the already existing training plan data at Firebase.
+Future<void> uploadTrainingPlanData(RawFirestoreData trainingPlans) async {
+  firestoreInstance
+      .collection('plan-entries')
+      .document("v6g6JVrNR3w5e8TklK4X")
+      .update(trainingPlans);
+}

--- a/lib/data/repository.dart
+++ b/lib/data/repository.dart
@@ -1,4 +1,3 @@
-import 'package:firedart/firedart.dart';
 import 'package:lifting_progress_tracker/data/network.dart';
 import 'package:lifting_progress_tracker/models/plan_entry.dart';
 
@@ -41,9 +40,6 @@ class TrainingPlanRepository {
     final Map<String, dynamic> trainingPlans = await getRawTrainingPlanData();
 
     trainingPlans[trainingPlanId] = planEntries;
-
-    final CollectionReference planEntryCollection =
-        Firestore.instance.collection('plan-entries');
-    planEntryCollection.document("v6g6JVrNR3w5e8TklK4X").update(trainingPlans);
+    uploadTrainingPlanData(trainingPlans);
   }
 }


### PR DESCRIPTION
Firestore update was still called in the repository layer, that should only handle data already fetched and leave Firestore instance calls to the network layer. (soC)